### PR TITLE
chore(deps): update default registry's baseline to `ce613c41372b23b1f51333815feb3edd87ef8a8b`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "$schema": "https://github.com/microsoft/vcpkg-tool/raw/refs/heads/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "builtin",
-    "baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf"
+    "baseline": "ce613c41372b23b1f51333815feb3edd87ef8a8b"
   },
   "registries": [
     {


### PR DESCRIPTION
This PR updates default registry's baseline to `ce613c41372b23b1f51333815feb3edd87ef8a8b`.